### PR TITLE
create fake signup function to simulate app functionality

### DIFF
--- a/src/Components/Postcard/SignIn.js
+++ b/src/Components/Postcard/SignIn.js
@@ -31,7 +31,7 @@ export default class SignIn extends Component {
                 Password
                 <input type="password" password="password" required />
               </label>
-              <button id="sign-in-btn" type="submit">Sign In</button>
+              <button id="sign-in-btn" type="submit" onClick={this.props.fakeSignUp}>Sign In</button>
             </form>
           </div>
         </div>

--- a/src/Components/Postcard/SignUp.js
+++ b/src/Components/Postcard/SignUp.js
@@ -36,7 +36,7 @@ export default class SignUp extends Component {
                 Email
                 <input type="email" name="email" required />
               </label>
-              <button id="sign-up-btn" type="submit">Sign Up</button>
+              <button id="sign-up-btn" type="submit" onClick={this.props.fakeSignUp}>Sign Up</button>
             </form>
           </div>
         </div>

--- a/src/app.js
+++ b/src/app.js
@@ -18,9 +18,10 @@ export default class App extends Component {
     this.openSignUpModal = this.openSignUpModal.bind(this);
     this.openSignInModal = this.openSignInModal.bind(this);
     this.closeModal = this.closeModal.bind(this);
+    this.fakeSignUp = this.fakeSignUp.bind(this);
 
     this.state = {
-      isLoggedIn: true,
+      isLoggedIn: false,
       postCardShowing: false,
       hasAccount: false,
       userId: '',
@@ -73,6 +74,14 @@ export default class App extends Component {
     })
   };
 
+  fakeSignUp(event) {
+    event.preventDefault();
+    this.setState({
+      isLoggedIn: true,
+      postCardShowing: false,
+    })
+  }
+
   render() {
     let modal = null;
     if (!this.state.hasAccount) {
@@ -80,6 +89,7 @@ export default class App extends Component {
         <SignUp
         postCardShowing={this.state.postCardShowing}
         closeModal={this.closeModal}
+        fakeSignUp={this.fakeSignUp}
         />
       )
     } else {
@@ -87,6 +97,7 @@ export default class App extends Component {
         <SignIn
         postCardShowing={this.state.postCardShowing}
         closeModal={this.closeModal}
+        fakeSignUp={this.fakeSignUp}
         />
       )
     }


### PR DESCRIPTION
Until we have JWT auth wired up, we needed a way to view and work with both the logged in and logged out states of the app without having to manually change the state in the code. fakeSignUp works both with the signup and signin modals, and simply changes the state of isLoggedIn from false to true, and also closes the modal. 